### PR TITLE
Intensify cron schedule: every 15 minutes from 15 to 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow everyday at 7pm
   schedule:
-    - cron: "0 17 * * *"
+    - cron: "*/15 15-17 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Bonjour, je suis en train de construire une interface sur la base de données ici présente (merci pour ce travail!)

J'ai pas mal d'idées derrière la tête mais beaucoup reposent autour de l'envoi de notification à la publication du BERA (alerte mail, etc..). Or ici le cron tourne une fois par jour à 18h heure Française, ce qui pourrait être jusqu'à 3h en retard de la publication.

Plutôt que de redévelopper la partie scrapping (en PHP en l'occurrence), je me dit que ça pourrait être facile d'intensifier les checks toutes les 15 minutes autour de l'horaire de publication comme ça à 15 minutes près je suis à jour.

Qu'en pensez-vous ?